### PR TITLE
Fixes per sommersoft's review

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -38,8 +38,8 @@ Implementation Notes
 * Adafruit's ESP32SPI library:
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
 """
-from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
+from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Adafruit_IO.git"

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -56,7 +56,7 @@ class RESTClient():
         """
         self.username = adafruit_io_username
         self.key = adafruit_io_key
-        if wifi_manager:
+        if isinstance(wifi, adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager):
             self.wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager object.")
@@ -89,7 +89,7 @@ class RESTClient():
         """Composes a valid API request path.
         :param str path: Adafruit IO API URL path.
         """
-        return "{0}/{1}/{2}/{3}".format('https://io.adafruit.com/api', 'v2', self.username, path)
+        return "https://io.adafruit.com/api/v2/{0}/{1}".format(self.username, path)
 
     # HTTP Requests
     def _post(self, path, payload):

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -39,6 +39,7 @@ Implementation Notes
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
 """
 from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError
+from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Adafruit_IO.git"
@@ -56,7 +57,7 @@ class RESTClient():
         """
         self.username = adafruit_io_username
         self.key = adafruit_io_key
-        if isinstance(wifi, adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager):
+        if isinstance(wifi_manager, adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager):
             self.wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager object.")

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,5 +5,5 @@ API
 .. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
 .. use this format as the module name: "adafruit_foo.foo"
 
-.. automodule:: adafruit_io
+.. automodule:: adafruit_io.adafruit_io
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@ extensions = [
     'sphinx.ext.todo',
 ]
 
+autodoc_mock_imports = ["digitalio", "busdevice", "neopixel", "adafruit_esp32spi"]
+
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
* Added explicit check for the `wifi` kwarg against `adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager` to make sure it's it's an instance of _WiFiManager, not something else accidentally passed in
* Changed api.rst to reflect directory structure
* Changed `_compose_path` to a more readable path.

Changes requested per: https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/pull/1