### PR TITLE
Remove adafruit_esp32spi_wifimanager import dependency 

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -35,8 +35,9 @@ Implementation Notes
 * Adafruit CircuitPython firmware for the supported boards:
     https://github.com/adafruit/circuitpython/releases
 
-* Adafruits ESP32SPI library:
+* Adafruit ESP32SPI or ESP_ATcontrol library:
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
+    https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol
 """
 from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError
 

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -35,7 +35,7 @@ Implementation Notes
 * Adafruit CircuitPython firmware for the supported boards:
     https://github.com/adafruit/circuitpython/releases
 
-* Adafruit's ESP32SPI library:
+* Adafruits ESP32SPI library:
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
 """
 from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -38,7 +38,6 @@ Implementation Notes
 * Adafruit's ESP32SPI library:
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
 """
-from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError
 
 __version__ = "0.0.0-auto.0"
@@ -57,7 +56,8 @@ class RESTClient():
         """
         self.username = adafruit_io_username
         self.key = adafruit_io_key
-        if isinstance(wifi_manager, adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager):
+        wifi_type = str(type(wifi_manager))
+        if ('ESPSPI_WiFiManager' in wifi_type):
             self.wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager object.")

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -52,12 +52,12 @@ class RESTClient():
         Creates an instance of the Adafruit IO REST Client.
         :param str adafruit_io_username: Adafruit IO Username
         :param str adafruit_io_key: Adafruit IO Key
-        :param wifi_manager: WiFiManager object from ESPSPI_WiFiManager or ESPAT_WifiManager
+        :param wifi_manager: WiFiManager object from ESPSPI_WiFiManager or ESPAT_WiFiManager
         """
         self.username = adafruit_io_username
         self.key = adafruit_io_key
         wifi_type = str(type(wifi_manager))
-        if ('ESPSPI_WiFiManager' in wifi_type or 'ESPAT_WifiManager' in wifi_type):
+        if ('ESPSPI_WiFiManager' in wifi_type or 'ESPAT_WiFiManager' in wifi_type):
             self.wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager object.")

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -52,12 +52,12 @@ class RESTClient():
         Creates an instance of the Adafruit IO REST Client.
         :param str adafruit_io_username: Adafruit IO Username
         :param str adafruit_io_key: Adafruit IO Key
-        :param wifi_manager: WiFiManager object from adafruit_esp32spi_wifimanager
+        :param wifi_manager: WiFiManager object from ESPSPI_WiFiManager or ESPAT_WifiManager
         """
         self.username = adafruit_io_username
         self.key = adafruit_io_key
         wifi_type = str(type(wifi_manager))
-        if ('ESPSPI_WiFiManager' in wifi_type):
+        if ('ESPSPI_WiFiManager' in wifi_type or 'ESPAT_WifiManager' in wifi_type):
             self.wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager object.")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,6 @@ extensions = [
     'sphinx.ext.todo',
 ]
 
-autodoc_mock_imports = ["digitalio", "busdevice", "neopixel", "adafruit_esp32spi"]
-
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Removing 

`        if isinstance(wifi_manager, adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager):	`

in favor of 

`        if ('ESPSPI_WiFiManager' in wifi_type or 'ESPAT_WiFiManager' in wifi_type):`

The library won't need to import `adafruit_esp32spi_wifimanager`, and this'll add more flexibility for future types of WiFiManager classes (such as the `ESPAT_WiFiManager` @jerryneedell  is working on. I've added support for that) 

* also removing `autodoc_mock_imports` from sphinx configuration, required by `adafruit_esp32spi_wifimanager`'s neopixel dependency 