### PR TITLE
Update examples for PyPortal board., default examples to pyportal

### DIFF
--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -19,20 +19,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -19,19 +19,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -20,19 +20,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -20,20 +20,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -18,20 +18,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -18,19 +18,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -18,21 +18,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -18,19 +18,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -19,20 +19,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -19,19 +19,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -20,19 +20,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -20,20 +20,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -27,19 +27,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -27,20 +27,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -21,21 +21,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -21,19 +21,19 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+# ESP32 Setup
+esp32_cs = DigitalInOut(board.D9)
+esp32_ready = DigitalInOut(board.D10)
+esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
 
 """
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)


### PR DESCRIPTION
* Removed `microcontroller` pin definitions in favor of nicer PyPortal `board.` pin names for all examples.
* Comment out ESP32 example pin setup, uncomment PyPortal.

Addressing https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/9

Tested on a PyPortal running CircuitPython 4.0.0b2 latest. 