### PR TITLE
Add optional precision kwarg for formatting floating point data

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -133,14 +133,20 @@ class RESTClient():
         return response.json()
 
     # Data
-    def send_data(self, feed_key, data, metadata=None):
+    def send_data(self, feed_key, data, metadata=None, precision=None):
         """
         Sends value data to a specified Adafruit IO feed.
         :param str feed_key: Adafruit IO feed key
         :param str data: Data to send to the Adafruit IO feed
         :param dict metadata: Optional metadata associated with the data
+        :param int precision: Optional amount of precision points to send with floating point data
         """
         path = self._compose_path("feeds/{0}/data".format(feed_key))
+        if precision:
+            try:
+                data = round(data, precision)
+            except NotImplementedError: # received a non-float value
+                raise NotImplementedError('Precision requires a floating point value')
         payload = self._create_data(data, metadata)
         self._post(path, payload)
 

--- a/examples/adafruit_io_simpletest_analog_in.py
+++ b/examples/adafruit_io_simpletest_analog_in.py
@@ -9,6 +9,9 @@ from digitalio import DigitalInOut
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 from analogio import AnalogIn
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
 
@@ -28,7 +31,11 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # ESP32 Setup
@@ -37,7 +44,8 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -29,10 +29,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -9,6 +9,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
 
@@ -25,7 +28,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -34,7 +41,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -10,6 +10,9 @@ from digitalio import DigitalInOut, Direction
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
 
@@ -26,7 +29,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -35,7 +42,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -30,10 +30,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -8,6 +8,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient
 
@@ -24,7 +27,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -33,7 +40,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -28,10 +28,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -18,7 +18,6 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-
 # ESP32 Setup
 esp32_cs = DigitalInOut(board.D9)
 esp32_ready = DigitalInOut(board.D10)
@@ -29,10 +28,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -8,6 +8,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient
 
@@ -24,7 +27,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -33,7 +40,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -29,10 +29,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -9,6 +9,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
 
@@ -25,7 +28,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -34,7 +41,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -30,10 +30,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -10,6 +10,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient
 
@@ -26,7 +29,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -35,7 +42,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -37,10 +37,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -14,6 +14,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
 
@@ -33,7 +36,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -42,7 +49,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -11,6 +11,9 @@ from digitalio import DigitalInOut
 # ESP32 SPI
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
 
+# Import NeoPixel Library
+import neopixel
+
 # Import Adafruit IO REST Client
 from adafruit_io.adafruit_io import RESTClient
 
@@ -27,7 +30,11 @@ esp32_ready = DigitalInOut(board.D10)
 esp32_reset = DigitalInOut(board.D5)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 """
 # PyPortal ESP32 Setup
@@ -36,7 +43,8 @@ esp32_ready = DigitalInOut(board.ESP_BUSY)
 esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 """
 
 # Set your Adafruit IO Username and Key in secrets.py

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -21,7 +21,6 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-
 # ESP32 Setup
 esp32_cs = DigitalInOut(board.D9)
 esp32_ready = DigitalInOut(board.D10)
@@ -32,10 +31,9 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOP
 
 """
 # PyPortal ESP32 Setup
-import microcontroller
-esp32_cs = DigitalInOut(microcontroller.pin.PB14)
-esp32_ready = DigitalInOut(microcontroller.pin.PB16)
-esp32_reset = DigitalInOut(microcontroller.pin.PB17)
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, board.NEOPIXEL)


### PR DESCRIPTION
Added `precision` kwarg to `send_data` to truncate floating point values to a specified `precision` decimal places before the payload is created and sent to Adafruit IO.

Addresses https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/12

Tested with PyPortal