### PR TITLE
Update variable names in examples for default secrets.py 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Create an Adafruit IO Client object
 
 .. code-block:: python
 
-   io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+   io = RESTClient(aio_username, aio_key, wifi)
 
 Sending data to an Adafruit IO feed
 

--- a/examples/adafruit_io_simpletest_analog_in.py
+++ b/examples/adafruit_io_simpletest_analog_in.py
@@ -51,11 +51,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 try:
     # Get the 'light' feed from Adafruit IO

--- a/examples/adafruit_io_simpletest_analog_in.py
+++ b/examples/adafruit_io_simpletest_analog_in.py
@@ -51,8 +51,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -48,8 +48,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -48,11 +48,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 try:
     # Get the 'temperature' feed from Adafruit IO

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -49,8 +49,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -49,11 +49,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 try:
     # Get the 'digital' feed from Adafruit IO

--- a/examples/adafruit_io_simpletest_esp_at.py
+++ b/examples/adafruit_io_simpletest_esp_at.py
@@ -59,11 +59,11 @@ wifi = adafruit_espatcontrol_wifimanager.ESPAT_WiFiManager(esp, secrets, status_
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 try:
     # Get the 'temperature' feed from Adafruit IO

--- a/examples/adafruit_io_simpletest_esp_at.py
+++ b/examples/adafruit_io_simpletest_esp_at.py
@@ -59,8 +59,8 @@ wifi = adafruit_espatcontrol_wifimanager.ESPAT_WiFiManager(esp, secrets, status_
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -47,11 +47,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 # Create a new 'circuitpython' feed with a description
 print('Creating new Adafruit IO feed...')

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -47,8 +47,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -47,8 +47,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -47,11 +47,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 # Create a new group
 print('Creating a new Adafruit IO Group...')

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -48,8 +48,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -48,11 +48,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 try:
     # Get the 'location' feed from Adafruit IO

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -49,11 +49,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 # Random Data ID
 # (to obtain this value, visit

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -49,8 +49,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -56,11 +56,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 try:
     # Get the 'temperature' feed from Adafruit IO

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -56,8 +56,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -50,11 +50,11 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['aio_username']
-ADAFRUIT_IO_KEY = secrets['aio_key']
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
-io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)
+io = RESTClient(aio_username, aio_key, wifi)
 
 # Weather Location ID
 # (to obtain this value, visit

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -50,8 +50,8 @@ wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_lig
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-ADAFRUIT_IO_USER = secrets['adafruit_io_user']
-ADAFRUIT_IO_KEY = secrets['adafruit_io_key']
+ADAFRUIT_IO_USER = secrets['aio_username']
+ADAFRUIT_IO_KEY = secrets['aio_key']
 
 # Create an instance of the Adafruit IO REST client
 io = RESTClient(ADAFRUIT_IO_USER, ADAFRUIT_IO_KEY, wifi)


### PR DESCRIPTION
Changing username and key strings in `examples` to match the default IO naming within `secrets.py`: https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/blob/master/adafruit_pyportal.py#L518