### PR TITLE
Add new IP-based time endpoint

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -274,9 +274,7 @@ class RESTClient():
         Returns a struct_time from the Adafruit IO Server based on the device's IP address.
         https://circuitpython.readthedocs.io/en/latest/shared-bindings/time/__init__.html#time.struct_time
         """
-        path = self._compose_path('integrations/time/clock.json')
+        path = self._compose_path('integrations/time/struct.json')
         time = self._get(path)
-        print(time)
-        print(time['wday'])
         return struct_time((time['year'], time['mon'], time['mday'], time['hour'],
                             time['min'], time['sec'], time['wday'], time['yday'], time['isdst']))

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -274,14 +274,9 @@ class RESTClient():
         Returns a struct_time from the Adafruit IO Server based on the device's IP address.
         https://circuitpython.readthedocs.io/en/latest/shared-bindings/time/__init__.html#time.struct_time
         """
-        path = self._compose_path('/integrations/time/clock.json{0}'.format(strftime_format))
-        time_response = self._get(path, return_text=True)
-        times = time_response.split(' ')
-        the_date = times[0]
-        the_time = times[1]
-        year_day = int(times[2])
-        week_day = int(times[3])
-        year, month, mday = [int(x) for x in the_date.split('-')]
-        the_time = the_time.split('.')[0]
-        hours, minutes, seconds = [int(x) for x in the_time.split(':')]
-        return struct_time((year, month, mday, hours, minutes, seconds, week_day, year_day, None))
+        path = self._compose_path('integrations/time/clock.json')
+        time = self._get(path)
+        print(time)
+        print(time['wday'])
+        return struct_time((time['year'], time['mon'], time['mday'], time['hour'],
+                            time['min'], time['sec'], time['wday'], time['yday'], time['isdst']))

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -120,18 +120,15 @@ class RESTClient():
         self._handle_error(response)
         return response.json()
 
-    def _get(self, path, return_text=False):
+    def _get(self, path):
         """
         GET data from Adafruit IO
         :param str path: Formatted Adafruit IO URL from _compose_path
-        :param bool return_text: Returns text instead of json
         """
         response = self.wifi.get(
             path,
             headers=self._create_headers(self._aio_headers[1]))
         self._handle_error(response)
-        if return_text:
-            return response.text
         return response.json()
 
     def _delete(self, path):

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -39,6 +39,7 @@ Implementation Notes
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
     https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol
 """
+from time import struct_time
 from adafruit_io.adafruit_io_errors import AdafruitIO_RequestError, AdafruitIO_ThrottleError
 
 __version__ = "0.0.0-auto.0"
@@ -268,10 +269,19 @@ class RESTClient():
         path = self._compose_path("integrations/words/{0}".format(generator_id))
         return self._get(path)
 
-    def receive_time(self, time_type):
+    def receive_time(self):
         """
-        Returns the current time from the Adafruit IO Server
-        :param string time_type: Type of time to be returned: millis, seconds, or ISO-8601
+        Returns a struct_time from the Adafruit IO Server based on the device's IP address.
+        https://circuitpython.readthedocs.io/en/latest/shared-bindings/time/__init__.html#time.struct_time
         """
-        path = 'https://io.adafruit.com/api/v2/time/{0}'.format(time_type)
-        return self._get(path, return_text=True)
+        path = self._compose_path('/integrations/time/clock.json{0}'.format(strftime_format))
+        time_response = self._get(path, return_text=True)
+        times = time_response.split(' ')
+        the_date = times[0]
+        the_time = times[1]
+        year_day = int(times[2])
+        week_day = int(times[3])
+        year, month, mday = [int(x) for x in the_date.split('-')]
+        the_time = the_time.split('.')[0]
+        hours, minutes, seconds = [int(x) for x in the_time.split(':')]
+        return struct_time((year, month, mday, hours, minutes, seconds, week_day, year_day, None))


### PR DESCRIPTION
This PR modifies the `receive_time` method to support the new time endpoint on Adafruit IO: `/integrations/time/struct.json`. This endpoint will return a time based on the IP Address.

The new `receive_time` returns the time as a `struct_time`(https://circuitpython.readthedocs.io/en/latest/shared-bindings/time/__init__.html#time.struct_time)

The previous /time endpoint returned a plaintext response, instead of json. Since the new endpoint returns a JSON response, this PR will remove the `return_text` kwarg from the HTTP `_get` method