### PR TITLE
Adding Example for API Coverage Tests

### DIFF
--- a/examples/adafruit_io_simpletest_api.py
+++ b/examples/adafruit_io_simpletest_api.py
@@ -66,9 +66,6 @@ def assertRaises(exc, func=None, *args, **kwargs):
     """Raises based on context.
     (from https://github.com/micropython/micropython-lib/blob/master/unittest/unittest.py)
     """
-    if func is None:
-        return AssertRaisesContext(exc)
-
     try:
         func(*args, **kwargs)
         assert False, "%r not raised" % exc
@@ -107,9 +104,7 @@ def delete_group(io_group_name):
         # feed doesnt exist
         pass
 
-"""
-Data Functionality
-"""
+# Data Functionality
 def send_receive():
     """Sending a random int. to a feed and receiving it back.
     send_data, receive_data
@@ -145,9 +140,7 @@ def send_location_data():
     assertAlmostEqual(float(rx_data['lon']), metadata['lon'])
     assertAlmostEqual(float(rx_data['ele']), metadata['ele'])
 
-"""
-Feed Functionality
-"""
+# Feed Functionality
 def test_create_feed():
     """create_new_feed
     """
@@ -161,34 +154,41 @@ def test_delete_feed():
     """
     print('Testing delete_feed...')
     delete_feed('testfeed')
-    test_feed = io.create_new_feed('testfeed')
+    io.create_new_feed('testfeed')
     assertRaises(AdafruitIO_RequestError, io.receive_data, 'testfeed')
 
 def test_delete_nonexistent_feed():
     """delete_feed
     """
-    print('Testing delete_feed...')
+    print('Testing delete_nonexistent_feed...')
     delete_feed('testfeed')
     assertRaises(AdafruitIO_RequestError, io.delete_feed, 'testfeed')
 
-"""
-Group Functionality
-"""
+def test_get_feed():
+    """get_feed
+    """
+    print('Testing get_feed...')
+    delete_feed('testfeed')
+    test_feed = io.create_new_feed('testfeed')
+    resp = io.get_feed(test_feed['key'])
+    print(resp)
+
+# Group Functionality
 def test_create_group():
     """create_new_group
     """
     print('Testing create_new_group...')
     delete_group('testgrp')
-    response = io.create_new_group('testgrp', 'testing')
-    assertEqual(response['name'], 'testgrp')
-    assertEqual(response['description'], 'testing')
+    resp = io.create_new_group('testgrp', 'testing')
+    assertEqual(resp['name'], 'testgrp')
+    assertEqual(resp['description'], 'testing')
 
 def test_delete_group():
     """delete_group
     """
     print('Testing delete_group...')
     delete_group('testgrp')
-    test_group = io.create_new_group('testgrp', 'testing')
+    io.create_new_group('testgrp', 'testing')
     delete_group('testgrp')
     assertRaises(AdafruitIO_RequestError, io.get_group, 'testgrp')
 
@@ -202,13 +202,13 @@ def test_get_group():
     assertEqual(test_group['name'], 'testgrp')
     assertEqual(test_group['key'], 'testgrp')
 
-def test_add_to_group():
+def test_add_feed_to_group():
     """add_feed_to_group
     """
     print('Testing add_feed_to_group...')
     delete_group('testgrp')
     delete_feed('testfeed')
-    test_feed = io.create_new_feed('testfeed')
+    io.create_new_feed('testfeed')
     test_group = io.create_new_group('testgrp', 'testing')
     io.add_feed_to_group('testgrp', 'testfeed')
     resp = io.get_group(test_group['key'])
@@ -216,9 +216,7 @@ def test_add_to_group():
     feeds = feeds[0]
     assertEqual(feeds['key'], 'testgrp.testfeed')
 
-"""
-Connected Services Functionality
-"""
+# Connected Services Functionality
 def test_receive_time():
     """receive_time
     """
@@ -245,9 +243,9 @@ def test_receive_random():
     assertIsNone(random_data['value'])
     assertIsNone(random_data['seed'])
 
-"""
-Test Configuration
-"""
+
+# Test Configuration
+
 # Weather Location ID, from https://io.adafruit.com/services/weather
 weather_location_id = 2127
 # Random Generator ID, from https://io.adafruit.com/services/words
@@ -255,12 +253,13 @@ random_data_id = 1461
 
 # Tests, organized by API endpoint type
 data_tests = [send_receive, send_location_data]
-feed_tests = [test_create_feed, test_delete_feed, test_delete_nonexistent_feed]
-group_tests = [test_create_group, test_delete_group, test_get_group, test_add_to_group]
-services_tests = [test_receive_time, test_receive_weather, test_receive_random] 
+feed_tests = [test_create_feed, test_delete_feed, test_delete_nonexistent_feed, test_get_feed]
+group_tests = [test_create_group, test_delete_group, test_get_group, test_add_feed_to_group]
+services_tests = [test_receive_time, test_receive_weather, test_receive_random]
 
 # Tests run by script
-tests = data_tests + feed_tests + group_tests + services_tests
+tests = feed_tests
+#tests = data_tests + feed_tests + group_tests + services_tests
 
 while True:
     start_time = time.monotonic()

--- a/examples/adafruit_io_simpletest_api.py
+++ b/examples/adafruit_io_simpletest_api.py
@@ -1,0 +1,116 @@
+"""
+Adafruit IO CircuitPython Tester
+---------------------------------------
+
+Tests methods within adafruit_io for
+compatibility with the Adafruit IO API.
+"""
+from random import randint, uniform
+import time
+import board
+import busio
+from digitalio import DigitalInOut
+
+# ESP32 SPI
+from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
+
+# Import NeoPixel Library
+import neopixel
+
+# Import Adafruit IO REST Client
+from adafruit_io.adafruit_io import RESTClient, AdafruitIO_RequestError
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+# PyPortal ESP32 Setup
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+
+# Set your Adafruit IO Username and Key in secrets.py
+# (visit io.adafruit.com if you need to create an account,
+# or if you need your Adafruit IO key.)
+aio_username = secrets['aio_username']
+aio_key = secrets['aio_key']
+
+
+def assertEqual(val_1, val_2):
+    """Raises an AssertionError if the two specified values are not equal.
+    """
+    if val_1 is not val_2:
+        raise AssertionError('Values are not equal:', val_1, val_2)
+
+def delete_feed(io_client, io_feed):
+    """Deletes a specified Adafruit IO Feed.
+    """
+    try:
+        io_client.delete_feed(io_feed)
+    except AdafruitIO_RequestError:
+        # feed doesnt exist
+        pass
+
+def send_receive():
+    """Sending a random int. to a feed and receiving it
+    """
+    print('Testing send_receive...')
+    io = RESTClient(aio_username, aio_key, wifi)
+    delete_feed(io, 'testfeed')
+    test_feed = io.create_new_feed('testfeed')
+    tx_data = randint(1, 100)
+    # send the value
+    io.send_data(test_feed['key'], tx_data)
+    # and get it back...
+    rx_data = io.receive_data(test_feed['key'])
+    assertEqual(int(rx_data['value']), tx_data)
+    print("OK!")
+
+def send_location_data():
+    """Sending a random location to a feed
+    """
+    print('Testing send_location_data...')
+    io = RESTClient(aio_username, aio_key, wifi)
+    delete_feed(io, 'testfeed')
+    test_feed = io.create_new_feed('testfeed')
+    # value
+    value = randint(0, 100)
+    # Set up metadata associated with value
+    metadata = {'lat': uniform(1, 100),
+                'lon': uniform(1, 100),
+                'ele': randint(0, 1000),
+                'created_at': None}
+    io.send_data(test_feed['key'], value, metadata)
+    rx_data = io.receive_data(test_feed['key'])
+    assertEqual(int(rx_data['value']), value)
+    assertEqual(float(rx_data['lat']), metadata['lat'])
+    assertEqual(float(rx_data['lon']), metadata['lon'])
+    assertEqual(int(rx_data['ele']), metadata['ele'])
+    assertEqual(rx_data['created_at'], metadata['created_at'])
+    print('OK!')
+
+# tests to run
+tests = [send_receive(), send_location_data()]
+
+# start the timer
+start_time = time.monotonic()
+while True:
+    try:
+        for i in len(tests) - 1:
+            print(i)
+            tests[test]
+            time.sleep(1)
+    except (ValueError, RuntimeError) as e:
+        print("Failed to get data, retrying\n", e)
+        wifi.reset()
+        continue
+    final_time = time.monotonic()
+    total_time = final_time-start_time
+    print("Ran {0} tests in {1}".format(len(tests), total_time))

--- a/examples/adafruit_io_simpletest_api.py
+++ b/examples/adafruit_io_simpletest_api.py
@@ -257,6 +257,7 @@ random_data_id = 1461
 data_tests = [send_receive, send_location_data]
 feed_tests = [test_create_feed, test_delete_feed, test_delete_nonexistent_feed, test_get_feed]
 group_tests = [test_create_group, test_delete_group, test_get_group, test_add_feed_to_group]
+# Note: the tests for random and weather requrie an active IO Plus subscription
 services_tests = [test_receive_time, test_receive_weather, test_receive_random]
 
 # Tests run by script

--- a/examples/adafruit_io_simpletest_api.py
+++ b/examples/adafruit_io_simpletest_api.py
@@ -90,11 +90,20 @@ def assertEqual(val_1, val_2):
     if val_1 != val_2:
         raise AssertionError('Values are not equal:', val_1, val_2)
 
-def delete_feed(io_feed):
+def delete_feed(io_feed_name):
     """Deletes a specified Adafruit IO Feed.
     """
     try:
-        io.delete_feed(io_feed)
+        io.delete_feed(io_feed_name)
+    except AdafruitIO_RequestError:
+        # feed doesnt exist
+        pass
+
+def delete_group(io_group_name):
+    """Deletes a specified Adafruit IO Group.
+    """
+    try:
+        io.delete_group(io_group_name)
     except AdafruitIO_RequestError:
         # feed doesnt exist
         pass
@@ -139,23 +148,13 @@ def send_location_data():
     assertAlmostEqual(float(rx_data['ele']), metadata['ele'])
     print('OK!')
 
-def test_receive_time():
-    """receive_time
-    """
-    print('Testing receive_time()...')
-    current_time = io.receive_time()
-    assertIsNone(current_time[0])
-    assertIsNone(current_time[1])
-    assertIsNone(current_time[2])
-    print('OK!')
-
 """
 Feed Functionality
 """
 def test_create_feed():
     """create_new_feed
     """
-    print('Test create_new_feed()')
+    print('Test create_new_feed')
     delete_feed('testfeed')
     test_feed = io.create_new_feed('testfeed')
     assertEqual(test_feed['name'], 'testfeed')
@@ -170,6 +169,9 @@ def test_delete_feed():
     assertRaises(AdafruitIO_RequestError, io.receive_data, 'testfeed')
 
 def test_delete_nonexistent_feed():
+    """delete_feed
+    """
+    print('Test delete_feed')
     delete_feed('testfeed')
     assertRaises(AdafruitIO_RequestError, io.delete_feed, 'testfeed')
 
@@ -177,9 +179,33 @@ def test_delete_nonexistent_feed():
 Group Functionality
 """
 
+def create_group():
+    print('Testing create_new_group()')
+    io.delete_group('testgroup')
+    response = io.create_new_group('testgroup', 'testing')
+    assertEqual(response['name'], 'testgroup')
+    assertEqual(response['description'], 'testing')
+
+# delete group, like delete feed
+
+# add a feed to a group and check if it's in the group
+
+"""
+Connected Services Functionality
+"""
+def test_receive_time():
+    """receive_time
+    """
+    print('Testing receive_time()...')
+    current_time = io.receive_time()
+    assertIsNone(current_time[0])
+    assertIsNone(current_time[1])
+    assertIsNone(current_time[2])
+    print('OK!')
+
 # tests to run
 tests = [send_receive, send_location_data, test_receive_time, test_create_feed,
-            test_delete_feed]
+            test_delete_feed, create_group]
 
 # start the timer
 start_time = time.monotonic()

--- a/examples/adafruit_io_simpletest_api.py
+++ b/examples/adafruit_io_simpletest_api.py
@@ -228,37 +228,43 @@ def test_receive_time():
     assertIsNone(current_time[1])
     assertIsNone(current_time[2])
 
-def test_receive_weather(weather_id):
+def test_receive_weather():
     """receive_weather
-    :param int weather_id: ID for retrieving a specified weather record.
     """
     print('Testing receive_weather...')
-    forecast = io.receive_weather(weather_id)
+    forecast = io.receive_weather(weather_location_id)
     current_forecast = forecast['current']
     assertIsNone(current_forecast['summary'])
     assertIsNone(current_forecast['temperature'])
 
+def test_receive_random():
+    """receive_random
+    """
+    print('Testing receive_random...')
+    random_data = io.receive_random_data(random_data_id)
+    assertIsNone(random_data['value'])
+    assertIsNone(random_data['seed'])
 
 """
 Test Configuration
 """
 # Weather Location ID, from https://io.adafruit.com/services/weather
-weather_location = 2127
+weather_location_id = 2127
 # Random Generator ID, from https://io.adafruit.com/services/words
-random_generator = 1461
+random_data_id = 1461
 
 # Tests, organized by API endpoint type
 data_tests = [send_receive, send_location_data]
 feed_tests = [test_create_feed, test_delete_feed, test_delete_nonexistent_feed]
 group_tests = [test_create_group, test_delete_group, test_get_group, test_add_to_group]
-services_tests = [test_receive_time, test_receive_weather(weather_location)] 
+services_tests = [test_receive_time, test_receive_weather, test_receive_random] 
 
 # Tests run by script
-tests = services_tests
-print(tests)
+tests = data_tests + feed_tests + group_tests + services_tests
 
 while True:
     start_time = time.monotonic()
+    print('Running %d tests...'%len(tests))
     try:
         for i in range(len(tests)):
             tests[i]()

--- a/examples/adafruit_io_simpletest_api.py
+++ b/examples/adafruit_io_simpletest_api.py
@@ -48,6 +48,8 @@ io = RESTClient(aio_username, aio_key, wifi)
 """
 Generic Test Assertions and Client Operations
 """
+
+#pylint: disable=keyword-arg-before-vararg
 def assertAlmostEqual(x, y, places=None, msg=''):
     """Raises an AssertionError if two float values are not equal.
     (from https://github.com/micropython/micropython-lib/blob/master/unittest/unittest.py)
@@ -62,7 +64,7 @@ def assertAlmostEqual(x, y, places=None, msg=''):
         msg = '%r != %r within %r places' % (x, y, places)
     assert False, msg
 
-def assertRaises(exc, func=None, *args, **kwargs):
+def assertRaises(exc,func=None, *args, **kwargs):
     """Raises based on context.
     (from https://github.com/micropython/micropython-lib/blob/master/unittest/unittest.py)
     """
@@ -150,7 +152,7 @@ def test_create_feed():
     assertEqual(test_feed['name'], 'testfeed')
 
 def test_delete_feed():
-    """delete_feed
+    """delete_feed by feed key
     """
     print('Testing delete_feed...')
     delete_feed('testfeed')
@@ -158,20 +160,20 @@ def test_delete_feed():
     assertRaises(AdafruitIO_RequestError, io.receive_data, 'testfeed')
 
 def test_delete_nonexistent_feed():
-    """delete_feed
+    """delete nonexistent feed by feed key
     """
     print('Testing delete_nonexistent_feed...')
     delete_feed('testfeed')
     assertRaises(AdafruitIO_RequestError, io.delete_feed, 'testfeed')
 
 def test_get_feed():
-    """get_feed
+    """get_feed by feed key
     """
     print('Testing get_feed...')
     delete_feed('testfeed')
     test_feed = io.create_new_feed('testfeed')
     resp = io.get_feed(test_feed['key'])
-    print(resp)
+    assertEqual(resp['key'], 'testfeed')
 
 # Group Functionality
 def test_create_group():
@@ -244,7 +246,7 @@ def test_receive_random():
     assertIsNone(random_data['seed'])
 
 
-# Test Configuration
+# Testing Setup
 
 # Weather Location ID, from https://io.adafruit.com/services/weather
 weather_location_id = 2127
@@ -258,15 +260,15 @@ group_tests = [test_create_group, test_delete_group, test_get_group, test_add_fe
 services_tests = [test_receive_time, test_receive_weather, test_receive_random]
 
 # Tests run by script
-tests = feed_tests
-#tests = data_tests + feed_tests + group_tests + services_tests
+tests = data_tests + feed_tests + group_tests + services_tests
 
 while True:
     start_time = time.monotonic()
     print('Running %d tests...'%len(tests))
     try:
-        for i in range(len(tests)):
-            tests[i]()
+        for i in enumerate(tests):
+            i[1]()
+            # tests[i[1]]()
             print('OK!')
             time.sleep(1)
     except (ValueError, RuntimeError) as e:


### PR DESCRIPTION
This example is intended for verifying proposed/PR'd changes to the `adafruit_io` circuitpython client do not break compatibility and/or  Adafruit IO API functionality (if the API changes).

Tests verify different API endpoints and methods in `adafruit_io.py` - they've been categorized by endpoint type and can be pieced together if someone want's to pick/choose which tests are run by modifying `tests`

Output from PyPortal (CP 3.x Beta 6) running all `services_tests`
```
Running 13 tests...
Testing send_receive...
OK!
Testing send_location_data...
OK!
Testing create_new_feed...
OK!
Testing delete_feed...
OK!
Testing delete_nonexistent_feed...
OK!
Testing get_feed...
OK!
Testing create_new_group...
OK!
Testing delete_group...
OK!
Testing get_group...
OK!
Testing add_feed_to_group...
OK!
Testing receive_time...
OK!
Testing receive_weather...
OK!
Testing receive_random...
OK!
Ran 13 tests in 135.117 seconds
```