### PR TITLE
Close HTTP method responses

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -118,7 +118,9 @@ class RESTClient():
             json=payload,
             headers=self._create_headers(self._aio_headers[0]))
         self._handle_error(response)
-        return response.json()
+        json_data = response.json()
+        response.close()
+        return json_data
 
     def _get(self, path):
         """
@@ -129,7 +131,9 @@ class RESTClient():
             path,
             headers=self._create_headers(self._aio_headers[1]))
         self._handle_error(response)
-        return response.json()
+        json_data = response.json()
+        response.close()
+        return json_data
 
     def _delete(self, path):
         """
@@ -140,7 +144,9 @@ class RESTClient():
             path,
             headers=self._create_headers(self._aio_headers[0]))
         self._handle_error(response)
-        return response.json()
+        json_data = response.json()
+        response.close()
+        return json_data
 
     # Data
     def send_data(self, feed_key, data, metadata=None, precision=None):


### PR DESCRIPTION
Properly close responses (https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/blob/master/adafruit_esp32spi/adafruit_esp32spi_requests.py#L72) from HTTP methods and return only the JSON data.

Tested with `adafruit_io_simpletest_api.py` and PyPortal (CPY 3b6)
> Ran 13 tests in 138.637 seconds