### PR TITLE
Update simpletest examples to detect boards with built-in ESP32

### DIFF
--- a/examples/adafruit_io_simpletest_analog_in.py
+++ b/examples/adafruit_io_simpletest_analog_in.py
@@ -27,16 +27,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_analog_in.py
+++ b/examples/adafruit_io_simpletest_analog_in.py
@@ -25,28 +25,23 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+# ESP32 Setup
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -23,27 +23,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_data.py
+++ b/examples/adafruit_io_simpletest_data.py
@@ -24,16 +24,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -25,16 +25,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_digital_out.py
+++ b/examples/adafruit_io_simpletest_digital_out.py
@@ -24,27 +24,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -23,16 +23,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_feeds.py
+++ b/examples/adafruit_io_simpletest_feeds.py
@@ -22,27 +22,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -23,16 +23,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_groups.py
+++ b/examples/adafruit_io_simpletest_groups.py
@@ -22,28 +22,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
-
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -23,27 +23,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_metadata.py
+++ b/examples/adafruit_io_simpletest_metadata.py
@@ -24,16 +24,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -25,16 +25,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_randomizer.py
+++ b/examples/adafruit_io_simpletest_randomizer.py
@@ -24,27 +24,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -31,27 +31,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,

--- a/examples/adafruit_io_simpletest_temperature.py
+++ b/examples/adafruit_io_simpletest_temperature.py
@@ -32,16 +32,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -26,16 +26,15 @@ except ImportError:
 
 # ESP32 Setup
 try:
-  esp32_cs = DigitalInOut(board.D9)
-  esp32_ready = DigitalInOut(board.D10)
-  esp32_reset = DigitalInOut(board.D5)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.ESP_CS)
+    esp32_ready = DigitalInOut(board.ESP_BUSY)
+    esp32_reset = DigitalInOut(board.ESP_RESET)
 except AttributeError:
-  esp32_cs = DigitalInOut(board.ESP_CS)
-  esp32_ready = DigitalInOut(board.ESP_BUSY)
-  esp32_reset = DigitalInOut(board.ESP_RESET)
-  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+    esp32_cs = DigitalInOut(board.D9)
+    esp32_ready = DigitalInOut(board.D10)
+    esp32_reset = DigitalInOut(board.D5)
 
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/adafruit_io_simpletest_weather.py
+++ b/examples/adafruit_io_simpletest_weather.py
@@ -25,27 +25,22 @@ except ImportError:
     raise
 
 # ESP32 Setup
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+try:
+  esp32_cs = DigitalInOut(board.D9)
+  esp32_ready = DigitalInOut(board.D10)
+  esp32_reset = DigitalInOut(board.D5)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+except AttributeError:
+  esp32_cs = DigitalInOut(board.ESP_CS)
+  esp32_ready = DigitalInOut(board.ESP_BUSY)
+  esp32_reset = DigitalInOut(board.ESP_RESET)
+  spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-"""Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 #status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-
-"""
-# PyPortal ESP32 Setup
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
-"""
 
 # Set your Adafruit IO Username and Key in secrets.py
 # (visit io.adafruit.com if you need to create an account,


### PR DESCRIPTION
This PR proposes updating examples to `try/except` on `board.D#`. This will let examples run on boards like the PyPortal/Metro M4 without editing the example code.

Examples tested with a PyPortal and an Feather M4 + AirLift Breakout