### PR TITLE
Implement network callbacks for Feed Subscribe/Unsubscribe

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -69,7 +69,7 @@ class IO_MQTT:
             )
         # MiniMQTT's username kwarg is optional, IO requires a username
         try:
-            self._user = self._client._user
+            self._user = self._client.user
         except:
             raise TypeError(
                 "Adafruit IO requires a username, please set one in MiniMQTT"
@@ -84,9 +84,11 @@ class IO_MQTT:
         self._client.on_connect = self._on_connect_mqtt
         self._client.on_disconnect = self._on_disconnect_mqtt
         self._client.on_message = self._on_message_mqtt
+        self._client.on_subscribe = self._on_subscribe_mqtt
+        self._client.on_unsubscribe = self._on_unsubscribe_mqtt
         self._logger = False
         # Write to the MiniMQTT logger, if avaliable.
-        if self._client._logger is not None:
+        if self._client.logger is not None:
             self._logger = True
             self._client.set_logger_level("DEBUG")
         self._connected = False
@@ -181,6 +183,24 @@ class IO_MQTT:
                 "You must define an on_message method before calling this callback."
             )
         self.on_message(self, topic_name, message)
+
+    # pylint: disable=not-callable
+    def _on_subscribe_mqtt(self, client, user_data, topic, qos):
+        """Runs when the client calls on_subscribe.
+        """
+        if self._logger:
+            self._client._logger.debug("Client called on_subscribe")
+        if self.on_subscribe is not None:
+            self.on_subscribe(self, user_data, topic, qos)
+
+    # pylint: disable=not-callable
+    def _on_unsubscribe_mqtt(self, client, user_data, topic, pid):
+        """Runs when the client calls on_unsubscribe.
+        """
+        if self._logger:
+            self._client._logger.debug("Client called on_unsubscribe")
+        if self.on_unsubscribe is not None:
+            self.on_unsubscribe(self, user_data, topic, pid)
 
     def loop(self):
         """Manually process messages from Adafruit IO.

--- a/examples/mqtt/adafruit_io_simpletest.py
+++ b/examples/mqtt/adafruit_io_simpletest.py
@@ -65,6 +65,14 @@ def connected(client):
     # Subscribe to changes on a feed named DemoFeed.
     client.subscribe("DemoFeed")
 
+def subscribe(client, userdata, topic, granted_qos):
+    # This method is called when the client subscribes to a new feed.
+    print('Subscribed to {0} with QOS level {1}'.format(topic, granted_qos))
+
+def unsubscribe(client, userdata, topic, pid):
+    # This method is called when the client unsubscribes from a feed.
+    print('Unsubscribed from {0} with PID {1}'.format(topic, pid))
+
 # pylint: disable=unused-argument
 def disconnected(client):
     # Disconnected function will be called when the client disconnects.
@@ -96,6 +104,8 @@ io = IO_MQTT(mqtt_client)
 # Connect the callback methods defined above to Adafruit IO
 io.on_connect = connected
 io.on_disconnect = disconnected
+io.on_subscribe = subscribe
+io.on_unsubscribe = unsubscribe
 io.on_message = message
 
 # Connect to Adafruit IO


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/25

* `_on_subscribe_mqtt` and `_on_unsubscribe_mqtt` added to Adafruit IO's `MQTT_API`
* Subscribing and unsubscribing to/from feeds will now correctly execute user-defined callback methods in user-code
* MQTT Simpletest example updated for `subscribe` and `unsubscribe`.

Code Test Result:
 * subscribed to feed -> `subscribe()` from code.py called
 * unsubscribed from feed -> `unsubscribe()` from code.py called
 * Publishing to feed does not change feed value, or call `message()` from code.
```
code.py output:
Connected to Adafruit IO!  Listening for DemoFeed changes...
Subscribed to brubell/feeds/DemoFeed with QOS level 0
Unsubscribed from brubell/feeds/DemoFeed with PID 2
Publishing a new message every 10 seconds...
Publishing 73 to DemoFeed.
Publishing 75 to DemoFeed.
```