### PR TITLE
remove loop_blocking

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -224,12 +224,6 @@ class IO_MQTT:
         """
         self._client.loop()
 
-    def loop_blocking(self):
-        """Starts a blocking loop and to processes messages
-        from Adafruit IO. Code below this call will not run.
-        """
-        self._client.loop_forever()
-
     # Subscriptions
     def subscribe(self, feed_key=None, group_key=None, shared_user=None):
         """Subscribes to your Adafruit IO feed or group.


### PR DESCRIPTION
satisfies #40 
As stated in the referenced issue, this lib's `loop_blocking()` will be broken upon next release of minimqtt lib. Thus I removed the method to preempt any incompatibility.