### PR TITLE
Fix Attribute Error, set_socket

### DIFF
--- a/examples/adafruit_io_mqtt/adafruit_io_groups.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_groups.py
@@ -11,7 +11,7 @@ from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 import neopixel
 from adafruit_io.adafruit_io import IO_MQTT
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 

--- a/examples/adafruit_io_mqtt/adafruit_io_location.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_location.py
@@ -10,7 +10,7 @@ import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 import neopixel
 
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
 
 ### WiFi ###

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_cellular.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_cellular.py
@@ -16,7 +16,7 @@ from adafruit_fona.adafruit_fona_gsm import GSM
 import adafruit_fona.adafruit_fona_socket as cellular_socket
 
 from adafruit_io.adafruit_io import IO_MQTT
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 # Get MQTT details and more from a secrets.py file
 try:

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_eth.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_eth.py
@@ -14,7 +14,7 @@ from digitalio import DigitalInOut
 from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 from adafruit_io.adafruit_io import IO_MQTT
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 # Get MQTT details and more from a secrets.py file
 try:

--- a/examples/adafruit_io_mqtt/adafruit_io_time.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_time.py
@@ -10,7 +10,7 @@ from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 import neopixel
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from adafruit_io.adafruit_io import IO_MQTT
 
 ### WiFi ###

--- a/examples/adafruit_io_simpletest.py
+++ b/examples/adafruit_io_simpletest.py
@@ -16,7 +16,7 @@ from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 import neopixel
 from adafruit_io.adafruit_io import IO_MQTT
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/42


Examples tested on `Adafruit CircuitPython 5.3.1 on 2020-07-13; Adafruit PyPortal with samd51j20`

---
groups
```
code.py output:
Connecting to WiFi...
Connected!
Connecting to Adafruit IO...
Connected to Adafruit IO!
Publishing new messages to group feeds every 5 seconds...
Publishing value 23 to feed: weatherstation.temperature
Publishing value 92 to feed: weatherstation.humidity
Feed ['temperature'] received new value: ['23']
Publishing value 97 to feed: weatherstation.temperature
Publishing value 25 to feed: weatherstation.humidity
```
---
location
```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Connecting to WiFi...
Connected!
Connected to Adafruit IO!
Sending data and location metadata to IO...
Data sent!
Feed location received new value: 42
```
---
simpletest
```
Connecting to WiFi...
Connected!
Connecting to Adafruit IO...
Connected to Adafruit IO!  Listening for DemoFeed changes...
Subscribed to brubell/feeds/DemoFeed with QOS level 0
Publishing a new message every 10 seconds...
Publishing 23 to DemoFeed.
Feed DemoFeed received new value: 23
Publishing 74 to DemoFeed.
Feed DemoFeed received new value: 74
```
