### PR TITLE
Clarify feed callback docstrings

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -210,7 +210,7 @@ class IO_MQTT:
         new value is written to the feed.
 
         NOTE: The callback_method registered to this method
-        will only execute after a call to loop().
+        will only execute during loop().
         :param str feed_key: Adafruit IO feed key.
         :param str callback_method: Name of callback method.
 
@@ -223,8 +223,8 @@ class IO_MQTT:
         """Removes a previously registered callback method
         from executing whenever feed_key receives new data.
 
-        If an on_message callback is registered, new messages
-        will now call on_message instead of the callback_method.
+        After this method is called, incoming messages
+        call the shared on_message.
         :param str feed_key: Adafruit IO feed key.
 
         """

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -205,8 +205,12 @@ class IO_MQTT:
             self.on_unsubscribe(self, user_data, topic, pid)
 
     def add_feed_callback(self, feed_key, callback_method):
-        """Executes callback_method whenever a message is
-        received on feed_key.
+        """Attaches a callback_method to an Adafruit IO feed.
+        The callback_method function is called when a
+        new value is written to the feed.
+
+        NOTE: The callback_method registered to this method
+        will only execute after a call to loop().
         :param str feed_key: Adafruit IO feed key.
         :param str callback_method: Name of callback method.
 
@@ -218,6 +222,9 @@ class IO_MQTT:
     def remove_feed_callback(self, feed_key):
         """Removes a previously registered callback method
         from executing whenever feed_key receives new data.
+
+        If an on_message callback is registered, new messages
+        will now call on_message instead of the callback_method.
         :param str feed_key: Adafruit IO feed key.
 
         """


### PR DESCRIPTION
Attempt to clarify `add_feed_callback` and `remove_feedback` functionality via docstrings, per @tannewt 's review here: https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/pull/46