### PR TITLE
adafruit_io_simpletest.py: fix aio_user to aio_username

### DIFF
--- a/examples/adafruit_io_mqtt/adafruit_io_groups.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_groups.py
@@ -87,7 +87,9 @@ MQTT.set_socket(socket, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_user"], password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
 )
 
 # Initialize an Adafruit IO MQTT Client

--- a/examples/adafruit_io_mqtt/adafruit_io_location.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_location.py
@@ -86,7 +86,9 @@ MQTT.set_socket(socket, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_user"], password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
 )
 
 # Initialize an Adafruit IO MQTT Client

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_cellular.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_cellular.py
@@ -85,7 +85,9 @@ MQTT.set_socket(cellular_socket, fona)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_user"], password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
 )
 
 # Initialize an Adafruit IO MQTT Client

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_eth.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_eth.py
@@ -70,7 +70,9 @@ MQTT.set_socket(socket, eth)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_user"], password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
 )
 
 # Initialize an Adafruit IO MQTT Client

--- a/examples/adafruit_io_mqtt/adafruit_io_time.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_time.py
@@ -100,7 +100,9 @@ MQTT.set_socket(socket, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_user"], password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
 )
 
 # Initialize an Adafruit IO MQTT Client

--- a/examples/adafruit_io_simpletest.py
+++ b/examples/adafruit_io_simpletest.py
@@ -100,7 +100,7 @@ MQTT.set_socket(socket, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_user"], password=secrets["aio_key"],
+    broker="io.adafruit.com", username=secrets["aio_username"], password=secrets["aio_key"],
 )
 
 

--- a/examples/adafruit_io_simpletest.py
+++ b/examples/adafruit_io_simpletest.py
@@ -100,7 +100,9 @@ MQTT.set_socket(socket, esp)
 
 # Initialize a new MQTT Client object
 mqtt_client = MQTT.MQTT(
-    broker="io.adafruit.com", username=secrets["aio_username"], password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
 )
 
 


### PR DESCRIPTION
This PR changes the  `aio_user` to `aio_username` to keep consistent with the [secrets.py](https://github.com/adafruit/circuitpython-default-files/blob/master/boards/pyportal/4.x/secrets.py#L10) file.

Currently a new maker will have a default secrets.py file with `aio_username` and this example will break.