### PR TITLE
Fix Throttling Message Parsing

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -174,6 +174,8 @@ class IO_MQTT:
                     messages.append(payload)
                 topic_name = feeds
                 message = messages
+            elif topic_name[1] == "throttle":
+                raise AdafruitIO_ThrottleError(payload)
             elif topic_name[0] == "time":
                 # Adafruit IO Time Topic
                 topic_name = topic_name[1]

--- a/adafruit_io/adafruit_io_errors.py
+++ b/adafruit_io/adafruit_io_errors.py
@@ -28,13 +28,7 @@ CircuitPython Adafruit IO Error Classes
 
 
 class AdafruitIO_ThrottleError(Exception):
-    """Adafruit IO request error class for rate-limiting"""
-
-    def __init__(self):
-        super().__init__(
-            "Number of Adafruit IO Requests exceeded! \
-                                                            Please try again in 30 seconds.."
-        )
+    """Adafruit IO request error class for rate-limiting."""
 
 
 class AdafruitIO_RequestError(Exception):


### PR DESCRIPTION
Messages on throttling topics now raise `AdafruitIO_ThrottleError`.

Fixes: https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/49

Tested on `Adafruit CircuitPython 6.0.0-rc.2 on 2020-11-12; Adafruit Metro M4 Airlift Lite with samd51j19`

Example Output:
```
Subscribed to brubell/throttle with QOS level 0
Publishing a new message every 10 seconds...
Publishing 26 to DemoFeed.
Publishing 38 to DemoFeed.
Publishing 25 to DemoFeed.
Publishing 67 to DemoFeed.
Publishing 79 to DemoFeed.
Publishing 92 to DemoFeed.
Publishing 22 to DemoFeed.
Publishing 2 to DemoFeed.
Publishing 33 to DemoFeed.
Publishing 45 to DemoFeed.
Publishing 92 to DemoFeed.
Publishing 64 to DemoFeed.
Publishing 15 to DemoFeed.
Traceback (most recent call last):
  File "code.py", line 128, in <module>
  File "/lib/adafruit_io/adafruit_io.py", line 246, in loop
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 706, in loop
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 733, in _wait_for_msg
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 273, in _handle_on_message
  File "/lib/adafruit_io/adafruit_io.py", line 178, in _on_message_mqtt
AdafruitIO_ThrottleError: "brubell data rate limit reached, 1 seconds until throttle released"```