### PR TITLE
Fix a typo in feed argument of IO_MQTT.get method

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -457,7 +457,7 @@ class IO_MQTT:
 
             io.get('temperature')
         """
-        self._client.publish("{0}/feeds{1}/get".format(self._user, feed_key), "\0")
+        self._client.publish("{0}/feeds/{1}/get".format(self._user, feed_key), "\0")
 
 
 class IO_HTTP:


### PR DESCRIPTION
To be honest I don't know if this is an actual typo, but all other accesses use `{0}/feeds/{1}` so it looks like a typo.