### PR TITLE
fix URL typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/adafruit/Adafruit_CircuitPython_Adafruit_IO/blob/master/CODE_OF_CONDUCT.md>`_
+<https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/blob/master/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Documentation

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -28,7 +28,7 @@ from adafruit_io.adafruit_io_errors import (
 )
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Adafruit_IO.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO.git"
 
 CLIENT_HEADERS = {"User-Agent": "AIO-CircuitPython/{0}".format(__version__)}
 


### PR DESCRIPTION
Just two typos in the __repo__ and readme