### PR TITLE
Add create_feed_in_group

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -589,16 +589,6 @@ class IO_HTTP:
         return self._delete(path)
 
     # Groups
-    def add_feed_to_group(self, group_key, feed_key):
-        """
-        Adds an existing feed to a group
-        :param str group_key: Group
-        :param str feed_key: Feed to add to the group
-        """
-        path = self._compose_path("groups/{0}/add".format(group_key))
-        payload = {"feed_key": feed_key}
-        return self._post(path, payload)
-
     def create_new_group(self, group_key, group_description):
         """
         Creates a new Adafruit IO Group.
@@ -624,6 +614,26 @@ class IO_HTTP:
         """
         path = self._compose_path("groups/{0}".format(group_key))
         return self._get(path)
+
+    def create_feed_in_group(self, group_key, feed_name):
+        """Creates a new feed in an existing group.
+        :param str group_key: Group name.
+        :param str feed_name: Name of new feed.
+
+        """
+        path = self._compose_path("groups/{0}/feeds".format(group_key))
+        payload = {"feed": {"name": feed_name}}
+        return self._post(path, payload)
+
+    def add_feed_to_group(self, group_key, feed_key):
+        """
+        Adds an existing feed to a group
+        :param str group_key: Group
+        :param str feed_key: Feed to add to the group
+        """
+        path = self._compose_path("groups/{0}/add".format(group_key))
+        payload = {"feed_key": feed_key}
+        return self._post(path, payload)
 
     # Feeds
     def get_feed(self, feed_key, detailed=False):


### PR DESCRIPTION
Adds matching function call for Create Feed in a Group Endpoint: https://io.adafruit.com/api/docs/#create-feed-in-a-group

Addresses https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/58

Tested on `Adafruit CircuitPython 6.1.0 on 2021-01-21; Adafruit PyPortal with samd51j20`

Test code:
```
# Create feed in group
print("Creating feed newfeed to group...")
io.create_feed_in_group(sensor_group["key"], "newfeed")


# Add the 'temperature' feed to the group
print("Adding feed temperature to group...")
io.add_feed_to_group(sensor_group["key"], "temperature")

```
Test result, feeds within newly created group on IO:
![image](https://user-images.githubusercontent.com/322428/106302703-48d38380-6227-11eb-9dc7-730e51f10d87.png)

