### PR TITLE
Add ESP32-S2 compatibility and example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+* `Adafruit CircuitPython MiniMQTT <https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT>`_
 
 Please ensure that all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
-* `Adafruit CircuitPython MiniMQTT <https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT>`_
 
 Please ensure that all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -51,9 +51,9 @@ class IO_MQTT:
             raise TypeError(
                 "This class requires a MiniMQTT client object, please create one."
             )
-        # MiniMQTT's username kwarg is optional, IO requires a username
+        # Adafruit IO MQTT API MUST require a username
         try:
-            self._user = self._client.user
+            self._user = self._client._username
         except Exception as err:
             raise TypeError(
                 "Adafruit IO requires a username, please set one in MiniMQTT"
@@ -70,11 +70,6 @@ class IO_MQTT:
         self._client.on_message = self._on_message_mqtt
         self._client.on_subscribe = self._on_subscribe_mqtt
         self._client.on_unsubscribe = self._on_unsubscribe_mqtt
-        self._logger = False
-        # Write to the MiniMQTT logger, if avaliable.
-        if self._client.logger is not None:
-            self._logger = True
-            self._client.set_logger_level("DEBUG")
         self._connected = False
 
     def __enter__(self):
@@ -112,8 +107,6 @@ class IO_MQTT:
     # pylint: disable=not-callable, unused-argument
     def _on_connect_mqtt(self, client, userdata, flags, return_code):
         """Runs when the client calls on_connect."""
-        if self._logger:
-            self._client._logger.debug("Client called on_connect.")
         if return_code == 0:
             self._connected = True
         else:
@@ -125,8 +118,6 @@ class IO_MQTT:
     # pylint: disable=not-callable, unused-argument
     def _on_disconnect_mqtt(self, client, userdata, return_code):
         """Runs when the client calls on_disconnect."""
-        if self._logger:
-            self._client._logger.debug("Client called on_disconnect")
         self._connected = False
         # Call the user-defined on_disconnect callblack if defined
         if self.on_disconnect is not None:
@@ -140,8 +131,6 @@ class IO_MQTT:
         :param str topic: MQTT topic response from Adafruit IO.
         :param str payload: MQTT payload data response from Adafruit IO.
         """
-        if self._logger:
-            self._client._logger.debug("Client called on_message.")
         if self.on_message is not None:
             # Parse the MQTT topic string
             topic_name = topic.split("/")
@@ -177,16 +166,12 @@ class IO_MQTT:
     # pylint: disable=not-callable
     def _on_subscribe_mqtt(self, client, user_data, topic, qos):
         """Runs when the client calls on_subscribe."""
-        if self._logger:
-            self._client._logger.debug("Client called on_subscribe")
         if self.on_subscribe is not None:
             self.on_subscribe(self, user_data, topic, qos)
 
     # pylint: disable=not-callable
     def _on_unsubscribe_mqtt(self, client, user_data, topic, pid):
         """Runs when the client calls on_unsubscribe."""
-        if self._logger:
-            self._client._logger.debug("Client called on_unsubscribe")
         if self.on_unsubscribe is not None:
             self.on_unsubscribe(self, user_data, topic, pid)
 

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_esp32s2.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_esp32s2.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+import time
+from random import randint
+
+import ssl
+import socketpool
+import wifi
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
+from adafruit_io.adafruit_io import IO_MQTT
+
+### WiFi ###
+
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# source control.
+# pylint: disable=no-name-in-module,wrong-import-order
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+# Set your Adafruit IO Username and Key in secrets.py
+# (visit io.adafruit.com if you need to create an account,
+# or if you need your Adafruit IO key.)
+aio_username = secrets["aio_username"]
+aio_key = secrets["aio_key"]
+
+print("Connecting to %s" % secrets["ssid"])
+wifi.radio.connect(secrets["ssid"], secrets["password"])
+print("Connected to %s!" % secrets["ssid"])
+
+# Define callback functions which will be called when certain events happen.
+# pylint: disable=unused-argument
+def connected(client):
+    # Connected function will be called when the client is connected to Adafruit IO.
+    # This is a good place to subscribe to feed changes.  The client parameter
+    # passed to this function is the Adafruit IO MQTT client so you can make
+    # calls against it easily.
+    print("Connected to Adafruit IO!  Listening for DemoFeed changes...")
+    # Subscribe to changes on a feed named DemoFeed.
+    client.subscribe("DemoFeed")
+
+
+def subscribe(client, userdata, topic, granted_qos):
+    # This method is called when the client subscribes to a new feed.
+    print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
+
+
+def unsubscribe(client, userdata, topic, pid):
+    # This method is called when the client unsubscribes from a feed.
+    print("Unsubscribed from {0} with PID {1}".format(topic, pid))
+
+
+# pylint: disable=unused-argument
+def disconnected(client):
+    # Disconnected function will be called when the client disconnects.
+    print("Disconnected from Adafruit IO!")
+
+
+# pylint: disable=unused-argument
+def message(client, feed_id, payload):
+    # Message function will be called when a subscribed feed has a new value.
+    # The feed_id parameter identifies the feed, and the payload parameter has
+    # the new value.
+    print("Feed {0} received new value: {1}".format(feed_id, payload))
+
+
+# Create a socket pool
+pool = socketpool.SocketPool(wifi.radio)
+
+# Initialize a new MQTT Client object
+mqtt_client = MQTT.MQTT(
+    broker="io.adafruit.com",
+    username=secrets["aio_username"],
+    password=secrets["aio_key"],
+    socket_pool=pool,
+    ssl_context=ssl.create_default_context(),
+)
+
+# Initialize an Adafruit IO MQTT Client
+io = IO_MQTT(mqtt_client)
+
+# Connect the callback methods defined above to Adafruit IO
+io.on_connect = connected
+io.on_disconnect = disconnected
+io.on_subscribe = subscribe
+io.on_unsubscribe = unsubscribe
+io.on_message = message
+
+# Connect to Adafruit IO
+print("Connecting to Adafruit IO...")
+io.connect()
+
+# Below is an example of manually publishing a new  value to Adafruit IO.
+last = 0
+print("Publishing a new message every 10 seconds...")
+while True:
+    # Explicitly pump the message loop.
+    io.loop()
+    # Send a new message every 10 seconds.
+    if (time.monotonic() - last) >= 5:
+        value = randint(0, 100)
+        print("Publishing {0} to DemoFeed.".format(value))
+        io.publish("DemoFeed", value)
+        last = time.monotonic()


### PR DESCRIPTION
This pull request:
* Adds a new usage example for using the library with native sockets.
* Updates library to reflect MiniMQTT release v5.0.0
* Removes redundant calls to MiniMQTT's `logger`.

Tested on `Adafruit CircuitPython 6.2.0-beta.1 on 2021-01-27; Adafruit Metro ESP32S2 with ESP32S2`.

Addresses https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/issues/52