### PR TITLE
Update _create_data for dict. metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: PyLint
-      run: |
-        pylint $( find . -path './adafruit*.py' )
-        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles
@@ -61,7 +57,12 @@ jobs:
       with:
         name: bundles
         path: ${{ github.workspace }}/bundles/
+    - name: Check For docs folder
+      id: need-docs
+      run: |
+        echo ::set-output name=docs::$( find . -wholename './docs' )
     - name: Build docs
+      if: contains(steps.need-docs.outputs.docs, 'docs')
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
     - name: Check For setup.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,18 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/pylint
+    rev: pylint-2.7.1
+    hooks:
+    -   id: pylint
+        name: pylint (library code)
+        types: [python]
+        exclude: "^(docs/|examples/|setup.py$)"
+-   repo: local
+    hooks:
+    -   id: pylint_examples
+        name: pylint (examples code)
+        description: Run pylint rules on "examples/*.py" files
+        entry: /usr/bin/env bash -c
+        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name $example; done)']
+        language: system

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -282,12 +282,10 @@ class IO_MQTT:
         Information about these topics can be found on the Adafruit IO MQTT API Docs.:
         https://io.adafruit.com/api/docs/mqtt.html#time-topics
         """
-        if "seconds" or "millis" or "hours" in time_type:
-            self._client.subscribe("time/" + time_type)
-        elif time_type == "iso":
+        if time_type == "iso":
             self._client.subscribe("time/ISO-8601")
         else:
-            raise TypeError("Invalid time feed type specified")
+            self._client.subscribe("time/" + time_type)
 
     def unsubscribe(self, feed_key=None, group_key=None, shared_user=None):
         """Unsubscribes from an Adafruit IO feed or group.

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -457,16 +457,16 @@ class IO_HTTP:
 
     @staticmethod
     def _create_data(data, metadata):
-        """Creates JSON data payload"""
-        if metadata is not None:
-            return {
-                "value": data,
-                "lat": metadata["lat"],
-                "lon": metadata["lon"],
-                "ele": metadata["ele"],
-                "created_at": metadata["created_at"],
-            }
-        return {"value": data}
+        """Returns a data payload as expected by the Adafruit IO HTTP API
+        :param data: Payload value.
+        :param dict metadata: Payload metadata.
+
+        """
+        payload = {"value": data}
+        if metadata:  # metadata is expected as a dict, append key/vals
+            for k, val in metadata.items():
+                payload[k] = val
+        return payload
 
     @staticmethod
     def _handle_error(response):


### PR DESCRIPTION
Update `_create_data` to allow metadata to be passed in as a dictionary without predefined keys.

Tested with adafruit_io_simpletest.py and adafruit_io_metadata.py examples on Feather M4 + AirLift

Related issue:
https://forums.adafruit.com/viewtopic.php?f=60&t=175772