### PR TITLE
Create send_batch_data method

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -565,14 +565,14 @@ class IO_HTTP:
         payload = self._create_data(data, metadata)
         self._post(path, payload)
 
-    def send_batch_data(self, feed, data_list):
+    def send_batch_data(self, feed_key, data_list):
         """
         Sends a batch array of data to a specified Adafruit IO feed
         :param str feed_key: Adafruit IO feed key
         :param list Data: Data list to send
         """
-        validate_feed_key(feed)
-        path = "feeds/{0}/data/batch".format(feed)
+        validate_feed_key(feed_key)
+        path = "feeds/{0}/data/batch".format(feed_key)
         data_dict = type(data_list)((data._asdict() for data in data_list))
         self._post(path, {"data": data_dict})
 

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -565,25 +565,16 @@ class IO_HTTP:
         payload = self._create_data(data, metadata)
         self._post(path, payload)
 
-    def send_batch_data(self, feed_key, data, metadata=None, precision=None):
+    def send_batch_data(self, feed, data_list):
         """
         Sends a batch array of data to a specified Adafruit IO feed
         :param str feed_key: Adafruit IO feed key
-        :param str data: Data to send
-        :param dict metadata: Optional metadata associated with the data
-        :param int precision: Optional amount of precision points to send with floating point data
+        :param list Data: Data list to send
         """
-        data = []
-        path = self._compose_path("feeds/{0}/data/batch".format(feed_key))
-        if precision:
-            try:
-                data = round(data, precision)
-            except NotImplementedError as err:
-                raise NotImplementedError(
-                    "Precision requires a floating point value"
-                ) from err
-        payload = self._create_data(data, metadata)
-        self._post(path, payload)
+        validate_feed_key(feed)
+        path = "feeds/{0}/data/batch".format(feed)
+        data_dict = type(data_list)((data._asdict() for data in data_list))
+        self._post(path, {"data": data_dict})
 
     def receive_all_data(self, feed_key):
         """

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -565,6 +565,26 @@ class IO_HTTP:
         payload = self._create_data(data, metadata)
         self._post(path, payload)
 
+    def send_batch_data(self, feed_key, data, metadata=None, precision=None):
+        """
+        Sends a batch array of data to a specified Adafruit IO feed
+        :param str feed_key: Adafruit IO feed key
+        :param str data: Data to send
+        :param dict metadata: Optional metadata associated with the data
+        :param int precision: Optional amount of precision points to send with floating point data
+        """
+        data = []
+        path = self._compose_path("feeds/{0}/data/batch".format(feed_key))
+        if precision:
+            try:
+                data = round(data, precision)
+            except NotImplementedError as err:
+                raise NotImplementedError(
+                    "Precision requires a floating point value"
+                ) from err
+        payload = self._create_data(data, metadata)
+        self._post(path, payload)
+
     def receive_all_data(self, feed_key):
         """
         Get all data values from a specified Adafruit IO feed. Data is


### PR DESCRIPTION
This would allow CircuitPython to send a batch array of data to be created from all available devices to the Adafruit.IO service. I will require further testing in all of my CircuitPython devices in the coming days and will mark this for review once it is complete.

Closes #72

Reference: https://io.adafruit.com/api/docs/?python#create-multiple-data-records