### PR TITLE
validate feed keys used needs to allow periods

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -40,9 +40,11 @@ def validate_feed_key(feed_key):
     """
     if len(feed_key) > 128:  # validate feed key length
         raise ValueError("Feed key must be less than 128 characters.")
-    if not bool(re.match("^[a-z0-9-]+$", feed_key)):  # validate key naming scheme
+    if not bool(
+        re.match(r"^[a-z0-9-]+(\.[a-z0-9-]+)?$", feed_key)
+    ):  # validate key naming scheme
         raise TypeError(
-            "Feed key must contain lower case English letters, numbers, and dash."
+            "Feed key must contain lower case English letters, numbers, dash, and one period."
         )
 
 


### PR DESCRIPTION
The recently introduced validate_feed_key [0] function
needs to account for cases when feed_id includes a
group. For example: "sign-quotes.signtext"

Fixes adafruit/Adafruit_CircuitPython_AdafruitIO#71

[0]: https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/commit/1e3d458ccbe86dade80ce3005a41ffed5d50b864