### PR TITLE
Modified regex to accept uppercase characters and a forward slash

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -44,7 +44,7 @@ def validate_feed_key(feed_key):
         re.match(r"^[a-zA-Z0-9-]+((\/|\.)[a-zA-Z0-9-]+)?$", feed_key)
     ):  # validate key naming scheme
         raise TypeError(
-            "Feed key must contain English letters, numbers, dash, and one period or one forward slash."
+            "Feed key must contain English letters, numbers, dash, and a period or a forward slash."
         )
 
 

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -41,10 +41,10 @@ def validate_feed_key(feed_key):
     if len(feed_key) > 128:  # validate feed key length
         raise ValueError("Feed key must be less than 128 characters.")
     if not bool(
-        re.match(r"^[a-z0-9-]+(\.[a-z0-9-]+)?$", feed_key)
+        re.match(r"^[a-zA-Z0-9-]+((\/|\.)[a-zA-Z0-9-]+)?$", feed_key)
     ):  # validate key naming scheme
         raise TypeError(
-            "Feed key must contain lower case English letters, numbers, dash, and one period."
+            "Feed key must contain English letters, numbers, dash, and one period or one forward slash."
         )
 
 


### PR DESCRIPTION
I should clarify that this lets you use a forward slash or a period, not both.