### PR TITLE
Call wifi.connect() after wifi.reset()

### DIFF
--- a/examples/adafruit_io_mqtt/adafruit_io_pubsub_rp2040.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_pubsub_rp2040.py
@@ -105,6 +105,7 @@ while True:
     except (ValueError, RuntimeError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()
+        wifi.connect()
         io.reconnect()
         continue
     # Send a new temperature reading to IO every 30 seconds


### PR DESCRIPTION
Need to explicitly call connect method after reset when WiFi manager is used with MQTT.
https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/100