### PR TITLE
Allow group feeds to be subscribed to and unsubscribed from

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -253,12 +253,14 @@ class IO_MQTT:
 
             client.subscribe([('temperature'), ('humidity')])
         """
-        validate_feed_key(feed_key)
         if shared_user is not None and feed_key is not None:
+            validate_feed_key(feed_key)
             self._client.subscribe("{0}/f/{1}".format(shared_user, feed_key))
         elif group_key is not None:
+            validate_feed_key(group_key)
             self._client.subscribe("{0}/g/{1}".format(self._user, group_key))
         elif feed_key is not None:
+            validate_feed_key(feed_key)
             self._client.subscribe("{0}/f/{1}".format(self._user, feed_key))
         else:
             raise AdafruitIO_MQTTError("Must provide a feed_key or group_key.")

--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -335,12 +335,14 @@ class IO_MQTT:
             client.unsubscribe('temperature', shared_user='adabot')
 
         """
-        validate_feed_key(feed_key)
         if shared_user is not None and feed_key is not None:
+            validate_feed_key(feed_key)
             self._client.unsubscribe("{0}/f/{1}".format(shared_user, feed_key))
         elif group_key is not None:
+            validate_feed_key(group_key)
             self._client.unsubscribe("{0}/g/{1}".format(self._user, feed_key))
         elif feed_key is not None:
+            validate_feed_key(feed_key)
             self._client.unsubscribe("{0}/f/{1}".format(self._user, feed_key))
         else:
             raise AdafruitIO_MQTTError("Must provide a feed_key or group_key.")


### PR DESCRIPTION
Currently it is not possible to subscribe to a group feed because `IO_MQTT#subscribe` validates `feed_key` unconditionally. When `group_key` is provided instead of `feed_key`, `feed_key` should not be required to be valid. This issue is also present in `IO_MQTT#unsubscribe`. 

This change makes it so that `IO_MQTT#subscribe` and `IO_MQTT#unsubscribe` validate `feed_key` and `group_key` only when one is provided.