### PR TITLE
Add create_and_get_feed function

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -686,6 +686,24 @@ class IO_HTTP:
         payload = {"name": feed_key, "description": feed_desc, "license": feed_license}
         return self._post(path, payload)
 
+    def create_and_get_feed(
+        self, feed_key, detailed=False, feed_desc=None, feed_license=None
+    ):
+        """
+        Attempts to return a feed; if the feed does not exist, it is created, and then returned.
+        :param str feed_key: Adafruit IO Feed Key
+        :param bool detailed: Returns a more verbose existing feed record
+        :param str feed_desc: Optional description of feed to be created
+        :param str feed_license: Optional feed license to be created
+        """
+        try:
+            return self.get_feed(feed_key, detailed=detailed)
+        except AdafruitIO_RequestError:
+            self.create_new_feed(
+                feed_key, feed_desc=feed_desc, feed_license=feed_license
+            )
+            return self.get_feed(feed_key, detailed=detailed)
+
     def delete_feed(self, feed_key):
         """
         Deletes an existing feed.

--- a/examples/adafruit_io_http/adafruit_io_create_and_get_feed.py
+++ b/examples/adafruit_io_http/adafruit_io_create_and_get_feed.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+Example using create_and_get_feed. Creates a new feed if it does not exist and sends to it, or
+sends to an existing feed once it has been created.
+"""
+import ssl
+import adafruit_requests
+import socketpool
+import wifi
+import microcontroller
+from adafruit_io.adafruit_io import IO_HTTP
+
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials, and "aio_username" and "aio_key" keys with your
+# Adafruit IO credentials, DO NOT share that file or commit it into Git or other
+# source control.
+# pylint: disable=no-name-in-module,wrong-import-order
+try:
+    from secrets import secrets
+except ImportError:
+    print(
+        "WiFi and Adafruit IO credentials are kept in secrets.py, please add them there!"
+    )
+    raise
+
+# Connect to Wi-Fi using credentials from secrets.py
+wifi.radio.connect(secrets["ssid"], secrets["password"])
+print("Connected to {}!".format(secrets["ssid"]))
+print("IP:", wifi.radio.ipv4_address)
+
+pool = socketpool.SocketPool(wifi.radio)
+requests = adafruit_requests.Session(pool, ssl.create_default_context())
+
+# Obtain Adafruit IO credentials from secrets.py
+aio_username = secrets["aio_username"]
+aio_key = secrets["aio_key"]
+
+# Initialize an Adafruit IO HTTP API object
+io = IO_HTTP(aio_username, aio_key, requests)
+
+# Create temperature variable using the CPU temperature and print the current value.
+temperature = microcontroller.cpu.temperature
+print("Current CPU temperature: {0} C".format(temperature))
+
+# Create and get feed.
+io.send_data(io.create_and_get_feed("cpu-temperature-feed")["key"], temperature)


### PR DESCRIPTION
Adds a `create_and_get_feed` function to the library that attempts to get the feed, and if the feed does not exist, it creates and then gets the feed. Eliminates the need for the `try`/`except` in examples that try to create a feed.

Included an example of how it might be used, using the CPU temperature, which works on most CP-compatible boards.