### PR TITLE
Add adafruit_minimqtt as setup.py requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "Adafruit_CircuitPython_ESP32SPI"],
+    install_requires=[
+        "Adafruit-Blinka",
+        "Adafruit_CircuitPython_ESP32SPI",
+        "Adafruit-CircuitPython-MiniMQTT",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
I believe this is what is causing the build failure for libraries such as https://github.com/adafruit/Adafruit_CircuitPython_PortalBase!