### PR TITLE
adafruit_io#unsubscribe(group_key=xxx) should unsubscribe thegroup ke…

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -351,7 +351,7 @@ class IO_MQTT:
             self._client.unsubscribe("{0}/f/{1}".format(shared_user, feed_key))
         elif group_key is not None:
             validate_feed_key(group_key)
-            self._client.unsubscribe("{0}/g/{1}".format(self._user, feed_key))
+            self._client.unsubscribe("{0}/g/{1}".format(self._user, group_key))
         elif feed_key is not None:
             validate_feed_key(feed_key)
             self._client.unsubscribe("{0}/f/{1}".format(self._user, feed_key))


### PR DESCRIPTION
fixes #87

I have not tested this. I only noted the inconsistency of `feed_key` vs `group_key`.

I would like this fix to go in the `adafruit-circuitpython-bundle-7.x-mpy`, please advise if I need to submit another PR, and against which tag/branch.