### PR TITLE
Change requirements to pypi format, remove ESP32SPI requirement

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+adafruit-circuitpython-esp32spi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-Adafruit_CircuitPython_ESP32SPI
-Adafruit_CircuitPython_MiniMQTT
+adafruit-circuitpython-minimqtt

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
     author_email="circuitpython@adafruit.com",
     install_requires=[
         "Adafruit-Blinka",
-        "Adafruit_CircuitPython_ESP32SPI",
-        "Adafruit-CircuitPython-MiniMQTT",
+        "adafruit-circuitpython-minimqtt",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
The library does not need ESP32SPI, it works on native wifi too.
The format used for the minimqtt requirement makes it listed in "external_dependencies" instead of "dependencies" in the bundle's json file. It might be what is tripping the project bundler for the learn guides using adafruit_io, or indirectly via portalbase. At least that's my assumption.

`adafruit_minimqtt` is missing from the Project Bundle there for example:
- https://learn.adafruit.com/magtag-weather/project-code
- https://learn.adafruit.com/pyportal-weather-station/code-pyportal-with-circuitpython
