### PR TITLE
Corrections to receive_n_data documentation

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -58,8 +58,7 @@ def validate_n_values(n_values: int):
     """Validates a provided number of values to retrieve data from Adafruit IO.
 
     Although Adafruit IO will accept values < 1 and > 1000, this avoids two types of issues:
-    <1      - Coding errors
-    >1000   - Pagination-related expectation management
+    n_values < 1 (coding errors) and n_values > 1000 (pagination required for HTTP API)
 
     """
     if n_values < 1 or n_values > 1000:  # validate 0 < n_values <= 1000
@@ -649,10 +648,11 @@ class IO_HTTP:
 
     def receive_n_data(self, feed_key: str, n_values: int):
         """
-        Get n data values from a specified Adafruit IO feed. Data is
+        Get most recent n data values from a specified feed. Data is
         returned in reverse order.
 
         :param str feed_key: Adafruit IO feed key
+        :param int n_values: Number of data values
         """
         validate_n_values(n_values)
         validate_feed_key(feed_key)


### PR DESCRIPTION
Hi, 

Thank you for approving my PR, it's my first ever and I am happy that I have added helpful functionality. 

Unfortuately, upon reviewing the docs, I found some omissions that now are corrected in this PR:

receive_n_data - [Link to Docs](https://docs.circuitpython.org/projects/adafruitio/en/latest/api.html#adafruit_io.adafruit_io.IO_HTTP.receive_n_data)
- Parameter description for n_values was missing, this has been added.
- Wording changes to specify "most recent n" to remove any ambiguity

validate_n_values - [Link to docs](https://docs.circuitpython.org/projects/adafruitio/en/latest/api.html#adafruit_io.adafruit_io.validate_n_values)
- Removed line breaks for better formatting in docs.

Thanks