### PR TITLE
Highlight usage of different methods for group feeds + cleanup multigroup feeds

### DIFF
--- a/examples/adafruit_io_http/adafruit_io_groups.py
+++ b/examples/adafruit_io_http/adafruit_io_groups.py
@@ -63,13 +63,24 @@ io = IO_HTTP(aio_username, aio_key, requests)
 print("Creating a new Adafruit IO Group...")
 sensor_group = io.create_new_group("envsensors", "a group of environmental sensors")
 
-# Add the 'temperature' feed to the group
-print("Adding feed temperature to group...")
-io.add_feed_to_group(sensor_group["key"], "temperature")
+# Create the 'temperature' feed in the group
+print("Creating feed temperature inside group...")
+io.create_feed_in_group(sensor_group["key"], "temperature")
+
+# Create the 'humidity' feed then add to group (it will still be in Default group too)
+print("Creating feed humidity then adding to group...")
+humidity_feed = io.create_new_feed("humidity", "a feed for humidity data")
+io.add_feed_to_group(sensor_group["key"], humidity_feed["key"])
 
 # Get info from the group
+print("Getting fresh group info...")
+sensor_group = io.get_group("envsensors")  # refresh data via HTTP API
 print(sensor_group)
 
 # Delete the group
 print("Deleting group...")
 io.delete_group("envsensors")
+
+# Delete the remaining humidity feed (it was in Two Groups so not deleted with our group)
+print("Deleting feed humidity (still in default group)...")
+io.delete_feed(humidity_feed["key"])


### PR DESCRIPTION
User feedback (support issue) was:

> Running a bit of the sample code from [https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/blob/main/examples/adafruit_io_http/adafruit_io_groups.py](https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/blob/main/examples/adafruit_io_http/adafruit_io_groups.py)
> I get this error:
> `Adafruit IO Error 404: not found - API documentation can be found at `[https://io.adafruit.com/api/docs](https://io.adafruit.com/api/docs)
> It seems that the API call `add_feed_to_group(..)` is not working

It appears the code has changed since the example was written and there is a newer "create_feed_in_group" method.
It's also the case that the `add_feed_to_group` method always required an existing feed (at least according to the comments in code).

I've expanded the example to:
1.  instead first create a feed in a group
2. then use the add a feed to a group method (with a newly created feed)
3. then **after deleting the group** only one of the feeds will be automatically removed (the one created **in** the group), as it has no references left to groups. 
Whereas the humidity one was created in the Default group and simply gained association to a second group. 
4. remove the humidity feed as a final step.


Fixes #119
