### PR TITLE
Add missing "on_publish" event callback in the class IO_MQTT - adafruit_io.py

### DIFF
--- a/adafruit_io/adafruit_io.py
+++ b/adafruit_io/adafruit_io.py
@@ -98,12 +98,14 @@ class IO_MQTT:
         self.on_message = None
         self.on_subscribe = None
         self.on_unsubscribe = None
+        self.on_publish = None
         # MQTT event callbacks
         self._client.on_connect = self._on_connect_mqtt
         self._client.on_disconnect = self._on_disconnect_mqtt
         self._client.on_message = self._on_message_mqtt
         self._client.on_subscribe = self._on_subscribe_mqtt
         self._client.on_unsubscribe = self._on_unsubscribe_mqtt
+        self._client.on_publish = self._on_publish_mqtt
         self._connected = False
 
     def __enter__(self):
@@ -200,6 +202,12 @@ class IO_MQTT:
                 "You must define an on_message method before calling this callback."
             )
         self.on_message(self, topic_name, message)
+
+    # pylint: disable=not-callable, unused-argument
+    def _on_publish_mqtt(self, client, user_data, topic, pid):
+        """Runs when the client calls on_publish."""
+        if self.on_publish is not None:
+            self.on_publish(self, user_data, topic, pid)
 
     # pylint: disable=not-callable
     def _on_subscribe_mqtt(self, client, user_data, topic, qos):

--- a/examples/adafruit_io_mqtt/adafruit_io_feed_callback.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_feed_callback.py
@@ -77,6 +77,15 @@ def disconnected(client):
 
 
 # pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
+
+
+# pylint: disable=unused-argument
 def on_message(client, feed_id, payload):
     # Message function will be called when a subscribed feed has a new value.
     # The feed_id parameter identifies the feed, and the payload parameter has
@@ -116,6 +125,7 @@ io.on_disconnect = disconnected
 io.on_subscribe = subscribe
 io.on_unsubscribe = unsubscribe
 io.on_message = on_message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 print("Connecting to Adafruit IO...")

--- a/examples/adafruit_io_mqtt/adafruit_io_groups.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_groups.py
@@ -73,6 +73,15 @@ def disconnected(client):
 
 
 # pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
+
+
+# pylint: disable=unused-argument
 def message(client, feed_id, payload):
     # Message function will be called when a subscribed feed has a new value.
     # The feed_id parameter identifies the feed, and the payload parameter has
@@ -105,6 +114,7 @@ io = IO_MQTT(mqtt_client)
 io.on_connect = connected
 io.on_disconnect = disconnected
 io.on_message = message
+io.on_publish = publish
 
 # Group name
 group_name = "weatherstation"

--- a/examples/adafruit_io_mqtt/adafruit_io_location.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_location.py
@@ -73,6 +73,15 @@ def disconnected(client):
 
 
 # pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
+
+
+# pylint: disable=unused-argument
 def message(client, feed_id, payload):
     # Message function will be called when a subscribed feed has a new value.
     # The feed_id parameter identifies the feed, and the payload parameter has
@@ -105,6 +114,7 @@ io = IO_MQTT(mqtt_client)
 io.on_connect = connected
 io.on_disconnect = disconnected
 io.on_message = message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 io.connect()

--- a/examples/adafruit_io_mqtt/adafruit_io_pubsub_rp2040.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_pubsub_rp2040.py
@@ -43,9 +43,19 @@ def connected(client):
     print("Connected to Adafruit IO! ")
 
 
+# pylint: disable=unused-argument
 def subscribe(client, userdata, topic, granted_qos):
     # This method is called when the client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
+
+
+# pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
 
 
 # pylint: disable=unused-argument
@@ -54,6 +64,7 @@ def disconnected(client):
     print("Disconnected from Adafruit IO!")
 
 
+# pylint: disable=unused-argument
 def on_led_msg(client, topic, message):
     # Method called whenever user/feeds/led has a new value
     print("New message on topic {0}: {1} ".format(topic, message))
@@ -90,6 +101,7 @@ io = IO_MQTT(mqtt_client)
 io.on_connect = connected
 io.on_disconnect = disconnected
 io.on_subscribe = subscribe
+io.on_publish = publish
 
 # Set up a callback for the led feed
 io.add_feed_callback("led", on_led_msg)

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_cellular.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_cellular.py
@@ -59,11 +59,13 @@ def connected(client):
     client.subscribe("DemoFeed")
 
 
+# pylint: disable=unused-argument
 def subscribe(client, userdata, topic, granted_qos):
     # This method is called when the client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
 
 
+# pylint: disable=unused-argument
 def unsubscribe(client, userdata, topic, pid):
     # This method is called when the client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
@@ -73,6 +75,15 @@ def unsubscribe(client, userdata, topic, pid):
 def disconnected(client):
     # Disconnected function will be called when the client disconnects.
     print("Disconnected from Adafruit IO!")
+
+
+# pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
 
 
 # pylint: disable=unused-argument
@@ -104,6 +115,7 @@ io.on_disconnect = disconnected
 io.on_subscribe = subscribe
 io.on_unsubscribe = unsubscribe
 io.on_message = message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 print("Connecting to Adafruit IO...")

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_esp32s2.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_esp32s2.py
@@ -56,11 +56,13 @@ def connected(client):
     client.subscribe("DemoFeed")
 
 
+# pylint: disable=unused-argument
 def subscribe(client, userdata, topic, granted_qos):
     # This method is called when the client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
 
 
+# pylint: disable=unused-argument
 def unsubscribe(client, userdata, topic, pid):
     # This method is called when the client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
@@ -70,6 +72,15 @@ def unsubscribe(client, userdata, topic, pid):
 def disconnected(client):
     # Disconnected function will be called when the client disconnects.
     print("Disconnected from Adafruit IO!")
+
+
+# pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
 
 
 # pylint: disable=unused-argument
@@ -103,6 +114,7 @@ io.on_disconnect = disconnected
 io.on_subscribe = subscribe
 io.on_unsubscribe = unsubscribe
 io.on_message = message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 print("Connecting to Adafruit IO...")

--- a/examples/adafruit_io_mqtt/adafruit_io_simpletest_eth.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_simpletest_eth.py
@@ -43,11 +43,13 @@ def connected(client):
     client.subscribe("DemoFeed")
 
 
+# pylint: disable=unused-argument
 def subscribe(client, userdata, topic, granted_qos):
     # This method is called when the client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
 
 
+# pylint: disable=unused-argument
 def unsubscribe(client, userdata, topic, pid):
     # This method is called when the client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
@@ -57,6 +59,15 @@ def unsubscribe(client, userdata, topic, pid):
 def disconnected(client):
     # Disconnected function will be called when the client disconnects.
     print("Disconnected from Adafruit IO!")
+
+
+# pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
 
 
 # pylint: disable=unused-argument
@@ -89,6 +100,7 @@ io.on_disconnect = disconnected
 io.on_subscribe = subscribe
 io.on_unsubscribe = unsubscribe
 io.on_message = message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 print("Connecting to Adafruit IO...")

--- a/examples/adafruit_io_mqtt/adafruit_io_time.py
+++ b/examples/adafruit_io_mqtt/adafruit_io_time.py
@@ -87,6 +87,15 @@ def disconnected(client):
 
 
 # pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print("Published to {0} with PID {1}".format(topic, pid))
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
+
+
+# pylint: disable=unused-argument
 def message(client, feed_id, payload):
     # Message function will be called when a subscribed feed has a new value.
     # The feed_id parameter identifies the feed, and the payload parameter has
@@ -119,6 +128,7 @@ io = IO_MQTT(mqtt_client)
 io.on_connect = connected
 io.on_disconnect = disconnected
 io.on_message = message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 io.connect()

--- a/examples/adafruit_io_simpletest.py
+++ b/examples/adafruit_io_simpletest.py
@@ -85,6 +85,15 @@ def disconnected(client):
 
 
 # pylint: disable=unused-argument
+def publish(client, userdata, topic, pid):
+    """This method is called when the client publishes data to a feed."""
+    print(f"Published to {topic} with PID {pid}")
+    if userdata is not None:
+        print("Published User data: ", end="")
+        print(userdata)
+
+
+# pylint: disable=unused-argument
 def message(client, feed_id, payload):
     # Message function will be called when a subscribed feed has a new value.
     # The feed_id parameter identifies the feed, and the payload parameter has
@@ -120,6 +129,7 @@ io.on_disconnect = disconnected
 io.on_subscribe = subscribe
 io.on_unsubscribe = unsubscribe
 io.on_message = message
+io.on_publish = publish
 
 # Connect to Adafruit IO
 print("Connecting to Adafruit IO...")


### PR DESCRIPTION
Adds callback method for on_publish, and updates examples to use it.

Fixes #122

Needs retesting on monday, marking draft until then